### PR TITLE
lets not forget the oft useful surveyor-respondent

### DIFF
--- a/2016-02-melb-nodejs/README.md
+++ b/2016-02-melb-nodejs/README.md
@@ -154,14 +154,16 @@ All relationships ever:
 - one to one
 - many to one
 - one to many
+- many to many
 
 ---
 ## Scalability patterns
 - pair (1:1)
 - req-res (n:1)
 - pub-sub (1:n)
-- pipeline (1:n:1)
+- pipeline, push-pull (1:n)
 - bus (n:n)
+- surveyor-respondent (1:n)
 
 ---
 ## Scalability patterns


### PR DESCRIPTION
@yoshuawuyts adding surveyor-respondent

interesting, and probably true that push-pull pipeline is labelled `(1:n:1)`

This label expresses the correct protocl semantics, but since, as a user of the lib, we don't really have access to the backpressure mechanism of a pipeline, _these internal protocol semantics I'm talking about_, I would instead call it `(1:n)`.. that's somewhat more aligned with the library's end-user control
